### PR TITLE
Default to checkboxes option

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -266,11 +266,11 @@
   (require racket/cmdline)
   (define next-release? #f)
   (define nightly? #t)
-  (define checkboxes #f)
+  (define checkboxes #t)
   (command-line
    #:once-each
    [("--release") "compare the next release" (set! next-release? #t)]
-   [("--checkboxes") "print as checkboxes for GitHub" (set! checkboxes #t)]
+   [("--no-checkboxes") "use sexp output format" (set! checkboxes #f)]
    [("--explain") "provide more details" (explain? #t)])
   (define (printer v)
     (if checkboxes


### PR DESCRIPTION
Updates the default output format to checkboxes in `main.rkt`.

- Changes the default value of the `checkboxes` variable to `#t`, making checkboxes the default output format.
- Replaces the `--checkboxes` command-line argument with `--no-checkboxes`, which sets the `checkboxes` variable to `#f` for users who prefer the sexp output format.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/samth/pkg-build-diff?shareId=baa3f78e-8456-4936-aafb-bae29047aa8d).